### PR TITLE
Fix build on linux (fails on non-portable d_namlen)

### DIFF
--- a/indexinfo.c
+++ b/indexinfo.c
@@ -142,8 +142,13 @@ parse_info_dir(int fd)
 		err(EXIT_FAILURE, "Impossible to open directory");
 
 	while ((dp = readdir(d)) != NULL) {
+#ifdef __linux__
+		if (_D_EXACT_NAMLEN(dp) < 5)
+			continue;
+#else
 		if (dp->d_namlen < 5)
 			continue;
+#endif
 		if ((ext = strrchr(dp->d_name, '.')) == NULL)
 			continue;
 		if (strcmp(ext, ".info") != 0)


### PR DESCRIPTION
There is no member of dirent structure names d_namlen on linux.
From linux's direct.h:
_D_EXACT_NAMLEN (DP) returns the length of DP->d_name, not including
its terminating null character.